### PR TITLE
Using readyState instead of state()

### DIFF
--- a/backbone-safesync.js
+++ b/backbone-safesync.js
@@ -3,11 +3,13 @@
     Backbone.sync = function(method, model, options) {
         var lastXHR = model._lastXHR && model._lastXHR[method];
 
-        if ((lastXHR && lastXHR.state() == 'pending') && (options && options.safe !== false))
+        if ((lastXHR && lastXHR.readyState != 4) && (options && options.safe !== false)) {
             lastXHR.abort('stale');
+        }
 
-        if (!model._lastXHR)
+        if (!model._lastXHR) {
             model._lastXHR = {};
+        }
 
         return model._lastXHR[method] = sync.apply(this, arguments);
     };

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf8">
+        <title>Backbone Bindings Test Suite</title>
+        <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.5.0.css" type="text/css">
+        <script src="http://code.jquery.com/qunit/qunit-git.js"></script>
+        <script src="http://zeptojs.com/zepto.min.js"></script>
+        <script src="http://documentcloud.github.com/underscore/underscore.js"></script>
+        <script src="http://documentcloud.github.com/backbone/backbone.js"></script>
+        <script src="../backbone-safesync.js"></script>
+        <script src="zepto_tests.js"></script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+    </body>
+</html>

--- a/test/zepto_tests.js
+++ b/test/zepto_tests.js
@@ -1,0 +1,45 @@
+var Book = Backbone.Model.extend();
+var Books = Backbone.Collection.extend({
+    model: Book,
+    url: 'https://www.googleapis.com/books/v1/volumes?q=javascript',
+  
+    parse: function(results){
+        return results.items;
+    }
+});
+
+test("test safe", function() {
+    var bookSearch = new Books(),
+        xhr1 = bookSearch.fetch(),
+        xhr2 = bookSearch.fetch();
+
+    equal(xhr1.readyState, 0);
+    equal(xhr2.readyState, 1);
+});
+
+test("test unsafe", function() {
+    var bookSearch = new Books([], {
+        searchTerm: 'django'
+    });
+
+    var xhr1 = bookSearch.fetch(),
+        xhr2 = bookSearch.fetch({
+            safe: false
+        });
+
+    equal(xhr1.readyState, 1);
+    equal(xhr2.readyState, 1);
+});
+
+test("test multiple collections", function() {
+    var bookSearch1 = new Books(),
+        bookSearch2 = new Books();
+
+    var xhr1_1 = bookSearch1.fetch();
+    var xhr2_1 = bookSearch2.fetch();
+    var xhr2_2 = bookSearch2.fetch();
+
+    equal(xhr2_1.readyState, 0);
+    equal(xhr1_1.readyState, 1);
+    equal(xhr2_2.readyState, 1);
+});


### PR DESCRIPTION
Hey there,

I wanted to use this patch in one of my current Backbone projects. However, I'm using Zepto instead of jQuery. Zepto XMLHttpRequest objects don't have the state() object, so I changed it to check for readyState instead so it can be used with Zepto. It doesn't seem to break any of your current jQuery tests. I also included a separate test file for verifying Zepto XHR objects / requests. If this seems to break something or not work as expected, let me know.
